### PR TITLE
DT-192_FixColourErrorMessage

### DIFF
--- a/src/components/modalWindow/modalWindow.tsx
+++ b/src/components/modalWindow/modalWindow.tsx
@@ -1,6 +1,7 @@
 import styles from 'src/components/modalWindow/modalWindow.module.scss';
 import { IResponse } from 'src/components/tempFolderForDevelop/responseHandler.ts';
 import PropTypes from 'prop-types';
+import { ErrorType } from 'src/utils/error/RequestErrors.ts';
 
 interface ModalWindowProps {
   data: IResponse;
@@ -11,7 +12,7 @@ const ModalWindow: React.FC<ModalWindowProps> = ({ data }) => {
   return (
     <div className={styles.parent}>
       <div
-        className={`${styles.children} ${status === 'Invalid' ? styles.error : styles.positive}`}
+        className={`${styles.children} ${ErrorType.includes(status) ? styles.error : styles.positive}`}
       >
         <span>{status}</span>
         <span>{message}</span>

--- a/src/utils/error/RequestErrors.ts
+++ b/src/utils/error/RequestErrors.ts
@@ -9,6 +9,8 @@ interface CommercetoolsErrorResponse {
   errors: CommercetoolsErrorDetail[];
 }
 
+export const ErrorType = ['Invalid', 'Error'];
+
 const isCommercetoolsError = (error: unknown): error is { body: CommercetoolsErrorResponse } => {
   return (
     typeof error === 'object' &&


### PR DESCRIPTION
1. Acceptance criteria:

- error messages should be red
Example: login with valid but wrong email/password

2. Screenshot (not technical tasks):
![image](https://github.com/comtvset/eCommerce-Application/assets/99416741/ea3bdfc3-0bca-476f-ae54-19af69221e91)


3. Comments
